### PR TITLE
Toutes annees

### DIFF
--- a/assets/map_style.css
+++ b/assets/map_style.css
@@ -14,6 +14,10 @@
     opacity: 0.5; /* Réglez l'opacité pour griser le bouton */
 }
 
+.anDesactive {
+    color: #6c757d; /* Couleur grise */
+}
+
 .curseur-date {
     grid-row: 2;
     width: 100%;

--- a/views/map3.php
+++ b/views/map3.php
@@ -167,19 +167,19 @@
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                     <form>
                         <div class="dropdown-item lumi">
-                            <input class="form-check-input mr-2" type="checkbox" value=1> Plein jour<br>
+                            <input class="form-check-input mr-2" type="checkbox" value=1 checked> Plein jour<br>
                         </div>
                         <div class="dropdown-item lumi">
-                            <input class="form-check-input mr-2" type="checkbox" value=2> Crépuscule ou aube<br>
+                            <input class="form-check-input mr-2" type="checkbox" value=2 checked> Crépuscule ou aube<br>
                         </div>
                         <div class="dropdown-item lumi">
-                            <input class="form-check-input mr-2" type="checkbox" value=3> Nuit sans éclairage public<br>
+                            <input class="form-check-input mr-2" type="checkbox" value=3 checked> Nuit sans éclairage public<br>
                         </div>
                         <div class="dropdown-item lumi">
-                            <input class="form-check-input mr-2" type="checkbox" value=4> Nuit avec éclairage public non allumé<br>
+                            <input class="form-check-input mr-2" type="checkbox" value=4 checked> Nuit avec éclairage public non allumé<br>
                         </div>
                         <div class="dropdown-item lumi">
-                            <input class="form-check-input mr-2" type="checkbox" value=5> Nuit avec éclairage public allumé<br>
+                            <input class="form-check-input mr-2" type="checkbox" value=5 checked> Nuit avec éclairage public allumé<br>
                         </div>
                     </form>
                 </div>
@@ -191,19 +191,19 @@
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                     <form>
                         <div class="dropdown-item meteo">
-                            <input class="form-check-input mr-2" type="checkbox" value="pluie"> Pluie<br>
+                            <input class="form-check-input mr-2" type="checkbox" value="pluie" checked> Pluie<br>
                         </div>
                         <div class="dropdown-item meteo">
-                            <input class="form-check-input mr-2" type="checkbox" value="brouillard"> Brouillard<br>
+                            <input class="form-check-input mr-2" type="checkbox" value="brouillard" checked> Brouillard<br>
                         </div>
                         <div class="dropdown-item meteo">
-                            <input class="form-check-input mr-2" type="checkbox" value="soleil"> Soleil<br>
+                            <input class="form-check-input mr-2" type="checkbox" value="soleil" checked> Soleil<br>
                         </div>
                         <div class="dropdown-item meteo">
-                            <input class="form-check-input mr-2" type="checkbox" value="neige"> Neige<br>
+                            <input class="form-check-input mr-2" type="checkbox" value="neige" checked> Neige<br>
                         </div>
                         <div class="dropdown-item meteo">
-                            <input class="form-check-input mr-2" type="checkbox" value="vent"> Vent<br>
+                            <input class="form-check-input mr-2" type="checkbox" value="vent" checked> Vent<br>
                         </div>
                     </form>
                 </div>
@@ -219,6 +219,7 @@
             <div id="map"></div>
             <div class="curseur-date">
                     <input type="range" min="2000" max="2022" v-model="selectedYear" id="dateSlider" @change="cherche_annee">
+                    <input class="form-check-input mr-2" type="checkbox" value=1 v-model="caseChecked" :disabled="caseDisabled" @change="annule_annee"> <span :class="{ 'anDesactive': caseDisabled }"> Toutes les années </span><br>
                     <p>Date sélectionnée : {{ selectedYear }}</p>
             </div>
         </div>


### PR DESCRIPTION
Ajout de la fonctionnalité (check) d'annuler l'annee selectionnée et de visulaiser les accidents selectionnes par luminosité pour une annee cette fois dans toutes les annees.  L'utilisitateur ne peut pas cocher cette case si toutes les annees sont deja selectionnées. Dans le menu déroulant luminosité et meteo, toutes les check sont a present cochées des le debut et sont a décocher selon la volonté de l'utilisateur.